### PR TITLE
chore(testing): More builder coverage

### DIFF
--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -225,13 +225,18 @@ func (b *PipelineBuilder) updatePipelines(app *plank.Application, pipelines []pl
 	if deleteStale {
 		// clear existing pipelines that weren't updated
 		b.Logger.Debug("Pipelines we should ignore because they were just created: ", ignoreList)
-		for _, p := range pipelines {
-			if !ignoreList[p.Name] {
-				b.Logger.Infof("Deleting stale pipeline %s", p.Name)
-				if err := b.Client.DeletePipeline(p); err != nil {
-					// Not worrying about handling errors here because it just means it
-					// didn't get deleted *this time*.
-					b.Logger.Warnf("Could not delete Pipeline %s (Application %s)", p.Name, p.Application)
+		allPipelines, err := b.Client.GetPipelines(app.Name)
+		if err != nil {
+			b.Logger.Errorf("Could not retrieve pipelines for %s: %s", app.Name, err.Error())
+		} else {
+			for _, p := range allPipelines {
+				if !ignoreList[p.Name] {
+					b.Logger.Infof("Deleting stale pipeline %s", p.Name)
+					if err := b.Client.DeletePipeline(p); err != nil {
+						// Not worrying about handling errors here because it just means it
+						// didn't get deleted *this time*.
+						b.Logger.Warnf("Could not delete Pipeline %s (Application %s)", p.Name, p.Application)
+					}
 				}
 			}
 		}

--- a/pkg/dinghyfile/builder_test.go
+++ b/pkg/dinghyfile/builder_test.go
@@ -18,10 +18,11 @@ package dinghyfile
 
 import (
 	"bytes"
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/armory/plank"
@@ -36,23 +37,102 @@ func TestProcessDinghyfile(t *testing.T) {
 
 	renderer := NewMockRenderer(ctrl)
 	renderer.EXPECT().Render(gomock.Eq("myorg"), gomock.Eq("myrepo"), gomock.Eq("the/full/path"), gomock.Any()).Return(bytes.NewBuffer([]byte(rendered)), nil).Times(1)
+
 	client := NewMockPlankClient(ctrl)
 	client.EXPECT().GetApplication(gomock.Eq("biff")).Return(&plank.Application{}, nil).Times(1)
 	client.EXPECT().GetPipelines(gomock.Eq("biff")).Return([]plank.Pipeline{}, nil).Times(1)
+
+	logger := NewMockFieldLogger(ctrl)
+	logger.EXPECT().Infof(gomock.Eq("Unmarshalled: %v"), gomock.Any()).Times(1)
+	logger.EXPECT().Infof(gomock.Eq("Found pipelines for %v: %v"), gomock.Any()).Times(1)
+	logger.EXPECT().Infof(gomock.Eq("Dinghyfile struct: %v"), gomock.Any()).Times(1)
+	logger.EXPECT().Infof(gomock.Eq("Updated: %s"), gomock.Any()).Times(1)
+	logger.EXPECT().Infof(gomock.Eq("Rendered: %s"), gomock.Any()).Times(1)
+	logger.EXPECT().Info(gomock.Eq("Looking up existing pipelines")).Times(1)
+
+	// Because we've set the renderer, we should NOT get this message...
+	logger.EXPECT().Info(gomock.Eq("Calling DetermineRenderer")).Times(0)
+
 	// Never gets UpsertPipeline because our Render returns no pipelines.
 	client.EXPECT().UpsertPipeline(gomock.Any(), "").Return(nil).Times(0)
-	pb := PipelineBuilder{
-		Renderer: renderer,
-		Client:   client,
-		Logger:   logrus.New(),
-	}
+	pb := testPipelineBuilder()
+	pb.Renderer = renderer
+	pb.Client = client
+	pb.Logger = logger
 	assert.Nil(t, pb.ProcessDinghyfile("myorg", "myrepo", "the/full/path"))
+}
+
+// Note: This ALSO tests the error case where the renderer fails (in this
+// example, because the rendered file path info is invalid)
+func TestProcessDinghyfileDefaultRenderer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := NewMockFieldLogger(ctrl)
+	logger.EXPECT().Info("Calling DetermineRenderer").Times(1)
+	logger.EXPECT().Error(gomock.Eq("Failed to download")).Times(1)
+	logger.EXPECT().Errorf(gomock.Eq("Failed to render dinghyfile %s: %s"), gomock.Eq("notfound"), gomock.Eq("File not found")).Times(1)
+
+	pb := testPipelineBuilder()
+	pb.Logger = logger
+	res := pb.ProcessDinghyfile("fake", "news", "notfound")
+	assert.NotNil(t, res)
+}
+
+func TestProcessDinghyfileFailedUnmarshal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rendered := `{blargh}`
+
+	renderer := NewMockRenderer(ctrl)
+	renderer.EXPECT().Render(gomock.Eq("myorg"), gomock.Eq("myrepo"), gomock.Eq("the/full/path"), gomock.Any()).Return(bytes.NewBuffer([]byte(rendered)), nil).Times(1)
+
+	logger := NewMockFieldLogger(ctrl)
+	logger.EXPECT().Errorf(gomock.Eq("UpdateDinghyfile malformed json: %s"), gomock.Any()).Times(1)
+	logger.EXPECT().Errorf(gomock.Eq("Failed to update dinghyfile %s: %s"), gomock.Any()).Times(1)
+	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+
+	pb := testPipelineBuilder()
+	pb.Logger = logger
+	pb.Renderer = renderer
+	res := pb.ProcessDinghyfile("myorg", "myrepo", "the/full/path")
+	assert.NotNil(t, res)
+}
+
+func TestProcessDinghyfileFailedUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rendered := `{"application": "testapp"}`
+
+	renderer := NewMockRenderer(ctrl)
+	renderer.EXPECT().Render(gomock.Eq("myorg"), gomock.Eq("myrepo"), gomock.Eq("the/full/path"), gomock.Any()).Return(bytes.NewBuffer([]byte(rendered)), nil).Times(1)
+
+	logger := NewMockFieldLogger(ctrl)
+	logger.EXPECT().Infof(gomock.Eq("Creating application '%s'..."), gomock.Eq("testapp")).Times(1)
+	logger.EXPECT().Errorf("Failed to create application (%s)", gomock.Any())
+	logger.EXPECT().Errorf(gomock.Eq("Failed to update Pipelines for %s: %s"), gomock.Eq("the/full/path")).Times(1)
+	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := NewMockPlankClient(ctrl)
+	client.EXPECT().GetApplication(gomock.Eq("testapp")).Return(nil, errors.New("not found")).Times(1)
+	client.EXPECT().CreateApplication(gomock.Any()).Return(errors.New("boom")).Times(1)
+
+	pb := testPipelineBuilder()
+	pb.Logger = logger
+	pb.Renderer = renderer
+	pb.Client = client
+	res := pb.ProcessDinghyfile("myorg", "myrepo", "the/full/path")
+	assert.NotNil(t, res)
+	assert.Equal(t, res.Error(), "boom")
 }
 
 // TestUpdateDinghyfile ONLY tests the function "updateDinghyfile" which,
 // despite its name, doesn't really update anything, it just unmarshals
 // the payload into the Dinghyfile{} struct.
 func TestUpdateDinghyfile(t *testing.T) {
+	b := testPipelineBuilder()
 
 	cases := map[string]struct {
 		dinghyfile []byte
@@ -129,7 +209,7 @@ func TestUpdateDinghyfile(t *testing.T) {
 
 	for testName, c := range cases {
 		t.Run(testName, func(t *testing.T) {
-			d, _ := UpdateDinghyfile(c.dinghyfile)
+			d, _ := b.UpdateDinghyfile(c.dinghyfile)
 			assert.Equal(t, d.ApplicationSpec, c.spec)
 		})
 	}
@@ -204,8 +284,33 @@ func TestUpdateDinghyfile(t *testing.T) {
 
 	for testName, c := range fullCases {
 		t.Run(testName, func(t *testing.T) {
-			d, _ := UpdateDinghyfile(c.dinghyRaw)
+			d, _ := b.UpdateDinghyfile(c.dinghyRaw)
 			assert.Equal(t, d, c.dinghyStruct)
 		})
 	}
+}
+
+func TestUpdateDinghyfileMalformed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	b := testPipelineBuilder()
+	logger := NewMockFieldLogger(ctrl)
+	b.Logger = logger
+	logger.EXPECT().Errorf(gomock.Eq("UpdateDinghyfile malformed json: %s"), gomock.Any()).Times(1)
+
+	df, err := b.UpdateDinghyfile([]byte("{ garbage"))
+	assert.Equal(t, err, ErrMalformedJSON)
+	assert.NotNil(t, df)
+}
+
+func TestDetermineRenderer(t *testing.T) {
+	// TODO:  Currently this will ALWAYS return a DinghyfileRenderer; when we
+	//        support additional types, we'll need to add those tests here.
+	b := testPipelineBuilder()
+	r := b.DetermineRenderer("dinghyfile")
+	assert.Equal(t, "*dinghyfile.DinghyfileRenderer", reflect.TypeOf(r).String())
+}
+
+func TestRebuildModuleRootes(t *testing.T) {
 }

--- a/pkg/dinghyfile/render_test.go
+++ b/pkg/dinghyfile/render_test.go
@@ -24,12 +24,9 @@ import (
 
 	"encoding/json"
 
-	"github.com/armory/dinghy/pkg/cache"
-	"github.com/armory/dinghy/pkg/events"
 	"github.com/armory/dinghy/pkg/git/dummy"
 	"github.com/armory/plank"
 	"github.com/golang/mock/gomock"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -297,25 +294,11 @@ var fileService = dummy.FileService{
 	"dict_keys_error": "",
 }
 
-// mock out events so that it gets passed over and doesn't do anything
-type EventsTestClient struct{}
-
-func (c *EventsTestClient) SendEvent(eventType string, event *events.Event) {}
-
 // This returns a test PipelineBuilder object.
 func testPipelineBuilder() *PipelineBuilder {
-	return &PipelineBuilder{
-		Depman:      cache.NewMemoryCache(),
-		Downloader:  fileService,
-		EventClient: &EventsTestClient{},
-		Logger:      logrus.New(),
-	}
-}
-
-// This sets a mock logger on the pipeline {
-func mockLogger(dr *DinghyfileRenderer, ctrl *gomock.Controller) *MockFieldLogger {
-	dr.Builder.Logger = NewMockFieldLogger(ctrl)
-	return dr.Builder.Logger.(*MockFieldLogger)
+	pb := testBasePipelineBuilder()
+	pb.Downloader = fileService
+	return pb
 }
 
 // For the most part, this is the base object to test against; you may need

--- a/pkg/dinghyfile/test_common.go
+++ b/pkg/dinghyfile/test_common.go
@@ -1,0 +1,59 @@
+/*
+* Copyright 2019 Armory, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+
+*    http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package dinghyfile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/armory/dinghy/pkg/cache"
+	"github.com/armory/dinghy/pkg/events"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+)
+
+// mock out events so that it gets passed over and doesn't do anything
+type EventsTestClient struct{}
+
+type partialMatcher struct {
+	y string
+}
+
+func (p partialMatcher) Matches(x interface{}) bool {
+	return strings.Contains(x.(string), p.y)
+}
+func (p partialMatcher) String() string {
+	return fmt.Sprintf("contains %v", p.y)
+}
+func containsString(x string) gomock.Matcher { return partialMatcher{x} }
+
+func (c *EventsTestClient) SendEvent(eventType string, event *events.Event) {}
+
+// This returns a test PipelineBuilder object.
+func testBasePipelineBuilder() *PipelineBuilder {
+	return &PipelineBuilder{
+		Depman:      cache.NewMemoryCache(),
+		EventClient: &EventsTestClient{},
+		Logger:      logrus.New(),
+	}
+}
+
+// This sets a mock logger on the pipeline {
+func mockLogger(dr *DinghyfileRenderer, ctrl *gomock.Controller) *MockFieldLogger {
+	dr.Builder.Logger = NewMockFieldLogger(ctrl)
+	return dr.Builder.Logger.(*MockFieldLogger)
+}


### PR DESCRIPTION
This actually found (and fixes) a bug where the "deleteStale" option would not work correctly to delete stale pipelines.