### PR TITLE
log(bitbucket): Add logging of query failures

### DIFF
--- a/pkg/git/bbcloud/push.go
+++ b/pkg/git/bbcloud/push.go
@@ -203,7 +203,7 @@ func handleDiffstatResponse(resp *http.Response, err error) (changedFiles []stri
 
 	err = json.Unmarshal(respRaw, &apiResponse)
 	if err != nil {
-		log.Warnf("Got error parsing JSON response from Bitbucket query %s: %s", url, respRaw)
+		log.Warnf("Got error parsing JSON response from Bitbucket query: %s", respRaw)
 		return []string{}, false, err
 	}
 

--- a/pkg/git/bbcloud/push.go
+++ b/pkg/git/bbcloud/push.go
@@ -203,6 +203,7 @@ func handleDiffstatResponse(resp *http.Response, err error) (changedFiles []stri
 
 	err = json.Unmarshal(respRaw, &apiResponse)
 	if err != nil {
+		log.Warnf("Got error parsing JSON response from Bitbucket query %s: %s", url, respRaw)
 		return []string{}, false, err
 	}
 

--- a/pkg/git/stash/push.go
+++ b/pkg/git/stash/push.go
@@ -113,6 +113,7 @@ func (p *Push) getFilesChanged(fromCommitHash, toCommitHash string, start int) (
 	log.Debugf("APIResponse: %+v\n", body)
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	if err != nil {
+		log.Warnf("Got error parsing JSON response from Stash query %s: %s", url, resp.Body)
 		return 0, err
 	}
 	if !body.IsLastPage {


### PR DESCRIPTION
If we get an unexpected/invalid response from Bitbucket (or Stash) when
we query for the changed files, log the URL used and the actual response
body so we can see what might have happened.