### PR TITLE
fix(logging): Set output for global logger

### DIFF
--- a/cmd/dinghy.go
+++ b/cmd/dinghy.go
@@ -63,8 +63,10 @@ func Start() {
 			log.Fatalf("Couldn't open log file")
 		}
 		log.SetOutput(f)
+		logr.SetOutput(f)
 	} else {
 		log.SetOutput(os.Stdout)
+		logr.SetOutput(os.Stdout)
 	}
 	logLevelStr := util.GetenvOrDefault("DEBUG_LEVEL", "info")
 	if config.Logging.Level != "" {


### PR DESCRIPTION
Until we refactor and use the log pointer "Everywhere", try to get it to
work grossly.