### PR TITLE
fix(bitbucket): fixes bitbucket cloud and server differentiation

### DIFF
--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -179,7 +179,6 @@ func (wa *WebAPI) stashWebhookHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (wa *WebAPI) bitbucketWebhookHandler(w http.ResponseWriter, r *http.Request) {
-	// determine if this is a bitbucket-cloud event and handle accordingly
 	keys := make(map[string]interface{})
 	if err := json.NewDecoder(r.Body).Decode(&keys); err != nil {
 		wa.Logger.Errorf("Unable to determine bitbucket event type: %s", err)
@@ -259,8 +258,9 @@ func (wa *WebAPI) bitbucketWebhookHandler(w http.ResponseWriter, r *http.Request
 
 		wa.buildPipelines(p, &fileService, w)
 
-	default: util.WriteHTTPError(w, http.StatusInternalServerError, errors.New("unknown bitbucket event type"))
-	return
+	default:
+		util.WriteHTTPError(w, http.StatusInternalServerError, errors.New("Unknown bitbucket event type"))
+		return
 	}
 }
 

--- a/pkg/web/routes_test.go
+++ b/pkg/web/routes_test.go
@@ -165,7 +165,7 @@ func TestBitbucketWebhookBadPayload(t *testing.T) {
 
 	wa := NewWebAPI(nil, nil, nil, nil, logger)
 
-	payload := bytes.NewBufferString(`{"event_type": "stash", "changes": "not an array"}`)
+	payload := bytes.NewBufferString(`{"event_type": "repo:refs_changed", "changes": "not an array"}`)
 
 	req := httptest.NewRequest("POST", "/v1/webhooks/bitbucket-cloud", payload)
 	rr := httptest.NewRecorder()
@@ -201,10 +201,26 @@ func TestBitbucketCloudWebhookBadPayload(t *testing.T) {
 
 	wa := NewWebAPI(nil, nil, nil, nil, logger)
 
-	payload := bytes.NewBufferString(`{"changes": "not an array"}`)
+	payload := bytes.NewBufferString(`{"event_type": "repo:push", "changes": "not an array"}`)
 
 	req := httptest.NewRequest("POST", "/v1/webhooks/bitbucket-cloud", payload)
 	rr := httptest.NewRecorder()
 	wa.bitbucketWebhookHandler(rr, req)
 	assert.Equal(t, rr.Code, 422)
+}
+
+func TestUnknownEventType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := mock.NewMockFieldLogger(ctrl)
+
+	wa := NewWebAPI(nil, nil, nil, nil, logger)
+
+	payload := bytes.NewBufferString(`{"event_type": "", "changes": "not an array"}`)
+
+	req := httptest.NewRequest("POST", "/v1/webhooks/bitbucket-cloud", payload)
+	rr := httptest.NewRecorder()
+	wa.bitbucketWebhookHandler(rr, req)
+	assert.Equal(t, 500, rr.Code)
 }


### PR DESCRIPTION
Fixes the determination between Bitbucket Cloud and Server. Lines up with the way that Echo is differentiating these event types. 