### PR TITLE
fix(github): Change ref of github to master from refs/heads/master

### DIFF
--- a/pkg/git/github/download.go
+++ b/pkg/git/github/download.go
@@ -35,17 +35,17 @@ type FileService struct {
 // note that "path" is the full path relative to the repo root
 // eg: src/foo/bar/filename
 func (f *FileService) Download(org, repo, path, branch string) (string, error) {
-	url := f.EncodeURL(org, repo, path, branch)
-	body := f.cache.Get(url)
-	if body != "" {
-		return body, nil
-	}
-
 	// The endpoint used by the Github lib (https://raw.githubusercontent.com/) does not
 	// accept branch names such as refs/heads/master, but only the name of the branch.
 	// Need to strip that if it exists. Can't use split here either, because '/' is allowed
 	// in branch names
 	branch = strings.Replace(branch, "refs/heads/", "", 1)
+
+	url := f.EncodeURL(org, repo, path, branch)
+	body := f.cache.Get(url)
+	if body != "" {
+		return body, nil
+	}
 
 	contents, err := f.GitHub.DownloadContents(org, repo, path, branch)
 	if err != nil {

--- a/pkg/git/github/push.go
+++ b/pkg/git/github/push.go
@@ -114,10 +114,7 @@ func (p *Push) IsBranch(branchToTry string) bool {
 
 // IsMaster detects if the branch is master.
 func (p *Push) IsMaster() bool {
-	if(p.Ref) == "master" {
-		return true;
-	}
-	return p.Ref == "refs/heads/master"
+	return p.Ref == "master" || p.Ref == "refs/heads/master"
 }
 
 // Name returns the name of the provider to be used in configuration

--- a/pkg/git/github/push.go
+++ b/pkg/git/github/push.go
@@ -114,6 +114,9 @@ func (p *Push) IsBranch(branchToTry string) bool {
 
 // IsMaster detects if the branch is master.
 func (p *Push) IsMaster() bool {
+	if(p.Ref) == "master" {
+		return true;
+	}
 	return p.Ref == "refs/heads/master"
 }
 

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -169,6 +169,8 @@ func (wa *WebAPI) githubWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p.Ref = "master"
+
 	// TODO: we're assigning config in two places here, we should refactor this
 	gh := github.Config{Endpoint: wa.Config.GithubEndpoint, Token: wa.Config.GitHubToken}
 	p.Config = gh

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -169,7 +169,7 @@ func (wa *WebAPI) githubWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.Ref = "master"
+	p.Ref = strings.Replace(p.Ref, "refs/heads/", "", 1)
 
 	// TODO: we're assigning config in two places here, we should refactor this
 	gh := github.Config{Endpoint: wa.Config.GithubEndpoint, Token: wa.Config.GitHubToken}


### PR DESCRIPTION
Dinghy was saving parents keys as:
Armory:dinghy:children:https://api.github.com/repos/armory-io/karlo-test/contents/dinghy/dinghyfile?ref=refs/heads/master

And searching for them as:
Armory:dinghy:parents:https://api.github.com/repos/armory-io/karlo-test-dinghy/contents/stage.test.module?ref=master

Removed the "refs/heads/" from the branch for github pushes.