### PR TITLE
fix(templates): templateOrg can be different from target repo

### DIFF
--- a/pkg/dinghyfile/parse.go
+++ b/pkg/dinghyfile/parse.go
@@ -268,8 +268,8 @@ func (r *DinghyfileParser) Parse(org, repo, path, branch string, vars []VarMap) 
 	// have an application in context?  So for now, hardcoding module branch
 	// to "master"
 	funcMap := template.FuncMap{
-		"module":     r.moduleFunc(org, "master", deps, vars),
-		"appModule":  r.moduleFunc(org, "master", deps, vars),
+		"module":     r.moduleFunc(r.Builder.TemplateOrg, "master", deps, vars),
+		"appModule":  r.moduleFunc(r.Builder.TemplateOrg, "master", deps, vars),
 		"pipelineID": r.pipelineIDFunc(vars),
 		"var":        r.varFunc(vars),
 		"makeSlice":  r.makeSlice,

--- a/pkg/settings/load.go
+++ b/pkg/settings/load.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/armory/go-yaml-tools/pkg/secrets"
-	"github.com/armory/go-yaml-tools/pkg/tls/server"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/armory/go-yaml-tools/pkg/secrets"
+	"github.com/armory/go-yaml-tools/pkg/tls/server"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -35,7 +37,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// DefaultDinghyPort is the default port that Dinghy will listen on.
+	DefaultDinghyPort = 8081
+)
+
 func NewDefaultSettings() Settings {
+	dinghyPort, err := strconv.ParseUint(util.GetenvOrDefault("DINGHY_PORT", string(DefaultDinghyPort)), 10, 32)
+
+	if err != nil {
+		dinghyPort = DefaultDinghyPort
+	}
+
 	return Settings{
 		DinghyFilename:    "dinghyfile",
 		TemplateRepo:      "dinghy-templates",
@@ -75,7 +88,7 @@ func NewDefaultSettings() Settings {
 		ParserFormat: "json",
 		RepoConfig:   []RepoConfig{},
 		Server: server.ServerConfig{
-			Port: 8081,
+			Port: uint32(dinghyPort),
 		},
 	}
 }


### PR DESCRIPTION
Previously modules were being pulled from the same organization that was
configured for the current repository. That is, if `org-a/project-a`
defined a `dinghyfile` in their repo, they could only source modules
from `org-a`, regardless of what was configured in their `dinghy`
config. This commit fixes this behavior so that the setting is honored.