### PR TITLE
feat(dinghy): Support for webhook secrets in dinghy

### DIFF
--- a/pkg/git/github/validateSecret.go
+++ b/pkg/git/github/validateSecret.go
@@ -22,6 +22,7 @@ func IsValidSignature(rawpayload []byte, webhookSecret string, key string) bool 
 	}
 
 	expectedHash := hex.EncodeToString(hash.Sum(nil))
-	log.Printf("Expected hash: %v and got %v from github", expectedHash, gotHash[1])
-	return gotHash[1] == expectedHash
+	validation := gotHash[1] == expectedHash
+	log.Printf("Result from hash validation was: %v", validation)
+	return validation
 }

--- a/pkg/git/github/validateSecret.go
+++ b/pkg/git/github/validateSecret.go
@@ -1,0 +1,38 @@
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"log"
+	"net/http"
+	"strings"
+)
+
+
+func IsValidSignature(rawpayload []byte, r *http.Request, key string) bool {
+	//X-Hub-Signature is the original header from github, but since this message is from echo we receive Webhook-secret
+	gotHash := strings.SplitN(r.Header.Get("webhook-secret"), "=", 2)
+	secretHeaderExists := true
+	validKey := key != ""
+	if gotHash[0] != "sha1" {
+		secretHeaderExists = false
+	}
+
+	// If there's a key and no header or viceversa then fail, if there is no header and no key then pass
+	if (validKey && !secretHeaderExists)  || (secretHeaderExists && !validKey){
+		return false
+	} else if !validKey && !secretHeaderExists {
+		return true
+	}
+
+	hash := hmac.New(sha1.New, []byte(key))
+	if _, err := hash.Write(rawpayload); err != nil {
+		log.Printf("Cannot compute the HMAC for request: %s\n", err)
+		return false
+	}
+
+	expectedHash := hex.EncodeToString(hash.Sum(nil))
+	log.Println("EXPECTED HASH:", expectedHash)
+	return gotHash[1] == expectedHash
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -40,8 +40,7 @@ type Settings struct {
 	StashUsername     string       `json:"stashUsername,omitempty" yaml:"stashUsername"`
 	StashToken        string       `json:"stashToken,omitempty" yaml:"stashToken"`
 	StashEndpoint     string       `json:"stashEndpoint,omitempty" yaml:"stashEndpoint"`
-	WebhookSecret     string       `json:"webhookSecret,omitempty" yaml:"webhookSecret"`
-	WebhookSecretEnabled     	string       `json:"webhookSecretEnabled,omitempty" yaml:"webhookSecretEnabled"`
+	WebhookValidations []WebhookValidation `json:"webhookValidations,omitempty" yaml:"webhookValidations"`
 	FiatUser          string       `json:"fiatUser,omitempty" yaml:"fiatUser"`
 	Logging           Logging      `json:"logging,omitempty" yaml:"logging"`
 	Secrets           Secrets      `json:"secrets,omitempty" yaml:"secrets"`
@@ -51,6 +50,16 @@ type Settings struct {
 	Server            server.ServerConfig `json:"server" yaml:"server"`
 	Http              client.Config       `json:"http" yaml:"http"`
 }
+
+type WebhookValidation struct {
+	Enabled 				bool	`json:"enabled,omitempty" yaml:"enabled"`
+	VersionControlProvider 	string	`json:"versionControlProvider,omitempty" yaml:"versionControlProvider"`
+	Organization 			string	`json:"organization,omitempty" yaml:"organization"`
+	Repo	 				string	`json:"repo,omitempty" yaml:"repo"`
+	Secret 					string	`json:"secret,omitempty" yaml:"secret"`
+}
+
+
 
 type spinnakerSupplied struct {
 	Orca    spinnakerService `json:"orca,omitempty" yaml:"orca"`

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -40,6 +40,8 @@ type Settings struct {
 	StashUsername     string       `json:"stashUsername,omitempty" yaml:"stashUsername"`
 	StashToken        string       `json:"stashToken,omitempty" yaml:"stashToken"`
 	StashEndpoint     string       `json:"stashEndpoint,omitempty" yaml:"stashEndpoint"`
+	WebhookSecret     string       `json:"webhookSecret,omitempty" yaml:"webhookSecret"`
+	WebhookSecretEnabled     	string       `json:"webhookSecretEnabled,omitempty" yaml:"webhookSecretEnabled"`
 	FiatUser          string       `json:"fiatUser,omitempty" yaml:"fiatUser"`
 	Logging           Logging      `json:"logging,omitempty" yaml:"logging"`
 	Secrets           Secrets      `json:"secrets,omitempty" yaml:"secrets"`

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -172,13 +172,13 @@ func (wa *WebAPI) githubWebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	if wa.Config.WebhookSecretEnabled == "true" {
 		if wa.Config.WebhookSecret == "" {
-			log.Error("webhookSecretEnabled functionality is enabled but no webhookSecret is present, " +
-				"webhook validation will not be done until webhookSecret is set, please add it as: " +
-				"hal armory dinghy edit --webhook-secret \"secret\" --webhook-secret-enabled")
+			log.Error("webhookSecretEnabled functionality is enabled but no webhookSecret value is present, " +
+				"webhook validation will not be done until webhookSecret is set, please add it following " +
+				"instructions from https://docs.armory.io/spinnaker/install_dinghy/")
 		} else {
 			webhookSecret := getWebhookSecret(r)
 			if webhookSecret == "" {
-				log.Error("Webhook secret is empty, please enable this functionality." )
+				log.Error("Webhook secret from repo is empty, please add it to the repo pushing the code." )
 				return
 			}
 			rawPayload := getRawPayload(body)


### PR DESCRIPTION
### Description
This change will enable webhook secrets validation for github repos in dinghy. 

### Limitation
- This functionality is for github only

### How to configure

1.  Add needed validation for repos with command: hal armory dinghy webhooksecrets github edit 
   Example: hal armory dinghy webhooksecrets github edit --organization armory --repo test-repo --enabled true --secret testSecret
     -  There are additional commands at: hal armory dinghy webhooksecrets github [edit | list | delete]

2. Deploy the configuration with: hal deploy apply 

### Details
Executing the hal armory dinghy webhooksecrets github edit will make changes to the .hal/config file, it will store the values inserted as a list, raw text in the file can be seen has:

```
armory:
    dinghy:
      enabled: true
      webhookValidations:
      - enabled: true
        versionControlProvider: github
        organization: armory-io
        repo: dinghy-test-jossue
        secret: test
```

When deployed this text will be move to the dinghy.ylm file as:
```
enabled: true
webhookValidations:
- enabled: true
  versionControlProvider: github
  organization: armory-io
  repo: dinghy-test-jossue
  secret: test
```

The dinghy.ylm file will be read by dinghy and parsed to the WebhookValidation struct when dingly starts.

### Changes
This feature include changes in halyard and echo:
Echo PR: https://github.com/armory-io/echo-armory/pull/138
Halyard PR: https://github.com/armory-io/halyard-armory/pull/299
