### PR TITLE
feat(dinghy): Changes to add enabled/disable webhook secret validation and default secret

### DIFF
--- a/pkg/git/github/validateSecret.go
+++ b/pkg/git/github/validateSecret.go
@@ -9,20 +9,23 @@ import (
 )
 
 
-func IsValidSignature(rawpayload []byte, webhookSecret string, key string) bool {
+func IsValidSignature(rawpayload []byte, webhookSecret string, key string, logger log.FieldLogger) bool {
 	gotHash := strings.SplitN(webhookSecret, "=", 2)
 	if gotHash[0] != "sha1" {
-		log.Error("Invalid webhook value")
+		logger.Error("Invalid webhook value")
 	}
 
 	hash := hmac.New(sha1.New, []byte(key))
 	if _, err := hash.Write(rawpayload); err != nil {
-		log.Printf("Cannot compute the HMAC for request: %s\n", err)
+		logger.Printf("Cannot compute the HMAC for request: %s\n", err)
 		return false
 	}
 
 	expectedHash := hex.EncodeToString(hash.Sum(nil))
 	validation := gotHash[1] == expectedHash
-	log.Printf("Result from hash validation was: %v", validation)
+	logger.Printf("Result from hash validation was: %v", validation)
+	if !validation {
+		logger.Error("Invalid webhook secret signature")
+	}
 	return validation
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -40,7 +40,6 @@ type Settings struct {
 	StashUsername     string       `json:"stashUsername,omitempty" yaml:"stashUsername"`
 	StashToken        string       `json:"stashToken,omitempty" yaml:"stashToken"`
 	StashEndpoint     string       `json:"stashEndpoint,omitempty" yaml:"stashEndpoint"`
-	WebhookValidations []WebhookValidation `json:"webhookValidations,omitempty" yaml:"webhookValidations"`
 	FiatUser          string       `json:"fiatUser,omitempty" yaml:"fiatUser"`
 	Logging           Logging      `json:"logging,omitempty" yaml:"logging"`
 	Secrets           Secrets      `json:"secrets,omitempty" yaml:"secrets"`
@@ -49,6 +48,8 @@ type Settings struct {
 	spinnakerSupplied `mapstructure:",squash"`
 	Server            server.ServerConfig `json:"server" yaml:"server"`
 	Http              client.Config       `json:"http" yaml:"http"`
+	WebhookValidations []WebhookValidation `json:"webhookValidations,omitempty" yaml:"webhookValidations"`
+	WebhookValidationEnabledProviders []string `json:"webhookValidationEnabledProviders,omitempty" yaml:"webhookValidationEnabledProviders"`
 }
 
 type WebhookValidation struct {


### PR DESCRIPTION
### Description:

- Added command for enable/disable.
     `hal armory dinghy webhooksecrets github [enable | disable]`

- Added a default repository that will be queried in case the org/repo is not found, this will be used as "default" repository for a generic secret (repo name: default-webhook-secret)

### Details:
- When feature is disabled no validations will be done.
- If feature is enabled:
    - Webhook validation exists:
      - Enabled is true
        - Webhook validation will be performed
      - Enabled is false
        - Webhook validation will not be performed (bypassed)
    - Webhook validation does not exists:
      - Webhook default-webhook-secret exists for that org
        - default-webhook-secret will be used as the original rule, same enabled logic will apply
     - Webhook default-webhook-secret  does not exists for that org
       - Error message will be logged and request will not be processed
