### PR TITLE
feat(pr-comment): update notifiers.go interface

### DIFF
--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -548,6 +548,8 @@ func (b *PipelineBuilder) getNotificationContent() map[string]interface{} {
 	} else {
 		content["logevent"] = logEvent.String()
 	}
-	content["rawdata"] = b.PushRaw
+	if b.PushRaw != nil {
+		content["rawdata"] = b.PushRaw
+	}
 	return content
 }

--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -548,7 +548,7 @@ func (b *PipelineBuilder) getContent() map[string]interface{} {
 	} else {
 		content["logevent"] = logEvent.String()
 	}
-
+	content["raw"] = b.PushRaw
 	return content
 
 }

--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -550,5 +550,4 @@ func (b *PipelineBuilder) getContent() map[string]interface{} {
 	}
 	content["raw"] = b.PushRaw
 	return content
-
 }

--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -42,11 +42,11 @@ type Parser interface {
 
 // PipelineBuilder is responsible for downloading dinghyfiles/modules, compiling them, and sending them to Spinnaker
 type PipelineBuilder struct {
-	Downloader           Downloader
-	Depman               DependencyManager
-	TemplateRepo         string
-	TemplateOrg          string
-	DinghyfileName       string
+	Downloader                  Downloader
+	Depman                      DependencyManager
+	TemplateRepo                string
+	TemplateOrg                 string
+	DinghyfileName              string
 	Client                      util.PlankClient
 	DeleteStalePipelines        bool
 	AutolockPipelines           string
@@ -168,7 +168,7 @@ func (b *PipelineBuilder) ValidatePipelines(d Dinghyfile, dinghyfile []byte) err
 
 	var lastErr error
 	var warning bool
-	for _, pipeline := range d.Pipelines{
+	for _, pipeline := range d.Pipelines {
 		validateResult := pipeline.ValidateRefIds()
 		for _, stageWarning := range validateResult.Warnings {
 			warning = true
@@ -233,7 +233,7 @@ func (b *PipelineBuilder) ProcessDinghyfile(org, repo, path, branch string) erro
 	if err != nil {
 		buf, errDownload := b.Downloader.Download(org, repo, path, branch)
 		if errDownload == nil {
-			b.NotifyFailure(org, repo, path, err, buf )
+			b.NotifyFailure(org, repo, path, err, buf)
 		} else {
 			b.NotifyFailure(org, repo, path, err, "")
 		}
@@ -271,7 +271,7 @@ func (b *PipelineBuilder) ProcessDinghyfile(org, repo, path, branch string) erro
 	} else {
 		if err := b.updatePipelines(&d.ApplicationSpec, d.Pipelines, d.DeleteStalePipelines, b.AutolockPipelines); err != nil {
 			b.Logger.Errorf("Failed to update Pipelines for %s: %s", path, err.Error())
-			b.NotifyFailure(org, repo, path, err, buf.String() )
+			b.NotifyFailure(org, repo, path, err, buf.String())
 			return err
 		}
 	}
@@ -424,7 +424,7 @@ func (b *PipelineBuilder) updatePipelines(app *plank.Application, pipelines []pl
 			b.Logger.Debug("Locking pipeline ", p.Name)
 			p.Lock()
 		}
-		
+
 		if err := b.Client.UpsertPipeline(p, p.ID); err != nil {
 			err = unwrapFront50Error(err)
 			b.Logger.Errorf("Upsert failed: %s", err.Error())
@@ -498,7 +498,7 @@ func (b *PipelineBuilder) AddUnmarshaller(u Unmarshaller) {
 
 func (b *PipelineBuilder) NotifySuccess(org, repo, path string, notifications plank.NotificationsType) {
 	for _, n := range b.Notifiers {
-		n.SendSuccess(org, repo, path, notifications)
+		n.SendSuccess(org, repo, path, notifications, b.getContent())
 	}
 }
 
@@ -510,7 +510,7 @@ func (b *PipelineBuilder) NotifyFailure(org, repo, path string, err error, dingh
 		}
 	}
 	for _, n := range b.Notifiers {
-		n.SendFailure(org, repo, path, err, notifications )
+		n.SendFailure(org, repo, path, err, notifications, b.getContent())
 	}
 }
 
@@ -537,4 +537,18 @@ func getParams(regEx, url string) (paramsMap map[string]string) {
 		}
 	}
 	return paramsMap
+}
+
+func (b *PipelineBuilder) getContent() map[string]interface{} {
+	content := map[string]interface{}{}
+
+	logEvent, err := b.Logger.GetBytesBuffByLoggerKey(log.LogEventKey)
+	if err != nil {
+		b.Logger.Info(fmt.Sprintf("there was an error trying to get content: %v", err))
+	} else {
+		content["logevent"] = logEvent.String()
+	}
+
+	return content
+
 }

--- a/pkg/dinghyfile/builder.go
+++ b/pkg/dinghyfile/builder.go
@@ -498,7 +498,7 @@ func (b *PipelineBuilder) AddUnmarshaller(u Unmarshaller) {
 
 func (b *PipelineBuilder) NotifySuccess(org, repo, path string, notifications plank.NotificationsType) {
 	for _, n := range b.Notifiers {
-		n.SendSuccess(org, repo, path, notifications, b.getContent())
+		n.SendSuccess(org, repo, path, notifications, b.getNotificationContent())
 	}
 }
 
@@ -510,7 +510,7 @@ func (b *PipelineBuilder) NotifyFailure(org, repo, path string, err error, dingh
 		}
 	}
 	for _, n := range b.Notifiers {
-		n.SendFailure(org, repo, path, err, notifications, b.getContent())
+		n.SendFailure(org, repo, path, err, notifications, b.getNotificationContent())
 	}
 }
 
@@ -539,15 +539,15 @@ func getParams(regEx, url string) (paramsMap map[string]string) {
 	return paramsMap
 }
 
-func (b *PipelineBuilder) getContent() map[string]interface{} {
+func (b *PipelineBuilder) getNotificationContent() map[string]interface{} {
 	content := map[string]interface{}{}
 
 	logEvent, err := b.Logger.GetBytesBuffByLoggerKey(log.LogEventKey)
 	if err != nil {
-		b.Logger.Info(fmt.Sprintf("there was an error trying to get content: %v", err))
+		b.Logger.Error(fmt.Sprintf("there was an error trying to get notification content: %v", err))
 	} else {
 		content["logevent"] = logEvent.String()
 	}
-	content["raw"] = b.PushRaw
+	content["rawdata"] = b.PushRaw
 	return content
 }

--- a/pkg/dinghyfile/builder_test.go
+++ b/pkg/dinghyfile/builder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/armory/dinghy/pkg/events"
 	"github.com/armory/dinghy/pkg/log"
 	"github.com/armory/dinghy/pkg/util"
-	"github.com/sirupsen/logrus"
 	"reflect"
 	"testing"
 
@@ -1299,16 +1298,7 @@ func TestPipelineBuilder_getContent(t *testing.T) {
 			name: "Content should return a map populated with 'raw' and 'logevent' properties",
 			fields: fields{
 				Logger: func() log.DinghyLog {
-					memLog := &bytes.Buffer{}
-					memLog.Write([]byte("test"))
-					l := log.DinghyLogs{Logs: map[string]log.DinghyLogStruct{
-						log.LogEventKey: {
-							Logger:         logrus.New(),
-							LogEventBuffer: memLog,
-						},
-					}}
-					l.Println("test")
-					return l
+					return NewDinghylogWithContent("test")
 				}(),
 				PushRaw: map[string]interface{}{},
 			},
@@ -1340,8 +1330,8 @@ func TestPipelineBuilder_getContent(t *testing.T) {
 				RebuildingModules:           tt.fields.RebuildingModules,
 				Action:                      tt.fields.Action,
 			}
-			if got := b.getContent(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getContent() = %v, want %v", got, tt.want)
+			if got := b.getNotificationContent(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getNotificationContent() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/dinghyfile/builder_test.go
+++ b/pkg/dinghyfile/builder_test.go
@@ -20,6 +20,10 @@ import (
 	"bytes"
 	"errors"
 	"github.com/armory/dinghy/pkg/dinghyfile/pipebuilder"
+	"github.com/armory/dinghy/pkg/events"
+	"github.com/armory/dinghy/pkg/log"
+	"github.com/armory/dinghy/pkg/util"
+	"github.com/sirupsen/logrus"
 	"reflect"
 	"testing"
 
@@ -1242,6 +1246,102 @@ pipelines:
 			}
 			if got != tt.want {
 				t.Errorf("extractApplicationName() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPipelineBuilder_getContent(t *testing.T) {
+	type fields struct {
+		Downloader                  Downloader
+		Depman                      DependencyManager
+		TemplateRepo                string
+		TemplateOrg                 string
+		DinghyfileName              string
+		Client                      util.PlankClient
+		DeleteStalePipelines        bool
+		AutolockPipelines           string
+		EventClient                 events.EventClient
+		Parser                      Parser
+		Logger                      log.DinghyLog
+		Ums                         []Unmarshaller
+		Notifiers                   []notifiers.Notifier
+		PushRaw                     map[string]interface{}
+		GlobalVariablesMap          map[string]interface{}
+		RepositoryRawdataProcessing bool
+		RebuildingModules           bool
+		Action                      pipebuilder.BuilderAction
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[string]interface{}
+	}{
+		{
+			name: "Content should return a map populated with 'raw' property if no Log Events are available",
+			fields: fields{
+				Logger: NewDinghylog(),
+				PushRaw: map[string]interface{}{
+					"head_commit": map[string]interface{}{
+						"id": "a5fc63bd5a8bdb342d1e83933a5b5c99010e61e4",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"raw": map[string]interface{}{
+					"head_commit": map[string]interface{}{
+						"id": "a5fc63bd5a8bdb342d1e83933a5b5c99010e61e4",
+					},
+				},
+			},
+		},
+		{
+			name: "Content should return a map populated with 'raw' and 'logevent' properties",
+			fields: fields{
+				Logger: func() log.DinghyLog {
+					memLog := &bytes.Buffer{}
+					memLog.Write([]byte("test"))
+					l := log.DinghyLogs{Logs: map[string]log.DinghyLogStruct{
+						log.LogEventKey: {
+							Logger:         logrus.New(),
+							LogEventBuffer: memLog,
+						},
+					}}
+					l.Println("test")
+					return l
+				}(),
+				PushRaw: map[string]interface{}{},
+			},
+			want: map[string]interface{}{
+				"raw":      map[string]interface{}{},
+				"logevent": "test",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &PipelineBuilder{
+				Downloader:                  tt.fields.Downloader,
+				Depman:                      tt.fields.Depman,
+				TemplateRepo:                tt.fields.TemplateRepo,
+				TemplateOrg:                 tt.fields.TemplateOrg,
+				DinghyfileName:              tt.fields.DinghyfileName,
+				Client:                      tt.fields.Client,
+				DeleteStalePipelines:        tt.fields.DeleteStalePipelines,
+				AutolockPipelines:           tt.fields.AutolockPipelines,
+				EventClient:                 tt.fields.EventClient,
+				Parser:                      tt.fields.Parser,
+				Logger:                      tt.fields.Logger,
+				Ums:                         tt.fields.Ums,
+				Notifiers:                   tt.fields.Notifiers,
+				PushRaw:                     tt.fields.PushRaw,
+				GlobalVariablesMap:          tt.fields.GlobalVariablesMap,
+				RepositoryRawdataProcessing: tt.fields.RepositoryRawdataProcessing,
+				RebuildingModules:           tt.fields.RebuildingModules,
+				Action:                      tt.fields.Action,
+			}
+			if got := b.getContent(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getContent() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/dinghyfile/builder_test.go
+++ b/pkg/dinghyfile/builder_test.go
@@ -69,8 +69,6 @@ func TestProcessDinghyfile(t *testing.T) {
 	assert.Nil(t, pb.ProcessDinghyfile("myorg", "myrepo", "the/full/path", "mybranch"))
 }
 
-
-
 func TestProcessDinghyfileValidate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -115,7 +113,6 @@ func TestUpdateApplication(t *testing.T) {
 	newPipelines := []plank.Pipeline{existingPipeline, newPipeline}
 
 	testapp := &plank.Application{Name: "testapp"}
-
 
 	client := NewMockPlankClient(ctrl)
 	client.EXPECT().GetApplication("testapp").Return(nil, nil).Times(1)
@@ -195,9 +192,9 @@ func TestProcessDinghyfileFailedUpdate(t *testing.T) {
 	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
 
 	client := NewMockPlankClient(ctrl)
-	client.EXPECT().GetApplication(gomock.Eq("testapp")).Return(nil, &plank.FailedResponse{StatusCode:404}).Times(1)
+	client.EXPECT().GetApplication(gomock.Eq("testapp")).Return(nil, &plank.FailedResponse{StatusCode: 404}).Times(1)
 	client.EXPECT().CreateApplication(gomock.Any()).Return(errors.New("boom")).Times(1)
-	client.EXPECT().GetApplicationNotifications(gomock.Eq("testapp")).Return(nil, &plank.FailedResponse{StatusCode:404}).Times(1)
+	client.EXPECT().GetApplicationNotifications(gomock.Eq("testapp")).Return(nil, &plank.FailedResponse{StatusCode: 404}).Times(1)
 
 	pb := testPipelineBuilder()
 	pb.Logger = logger
@@ -264,7 +261,7 @@ func TestProcessDinghyfileFailedValidation(t *testing.T) {
 	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
 
 	client := NewMockPlankClient(ctrl)
-	client.EXPECT().GetApplicationNotifications(gomock.Eq("foo")).Return(nil, &plank.FailedResponse{StatusCode:404}).Times(1)
+	client.EXPECT().GetApplicationNotifications(gomock.Eq("foo")).Return(nil, &plank.FailedResponse{StatusCode: 404}).Times(1)
 
 	pb := testPipelineBuilder()
 	pb.Logger = logger
@@ -437,13 +434,12 @@ func TestUpdateDinghyfile(t *testing.T) {
 	}
 }
 
-
 func TestValidatePipelines(t *testing.T) {
 	b := testPipelineBuilder()
 
 	fullCases := map[string]struct {
-		dinghyRaw    []byte
-		result       error
+		dinghyRaw []byte
+		result    error
 	}{
 		"dinghyraw_fail_no_refids": {
 			dinghyRaw: []byte(`{
@@ -649,7 +645,6 @@ func TestValidatePipelines(t *testing.T) {
 			}`),
 			result: errors.New("Duplicate stage refId mj2 field found"),
 		},
-
 	}
 
 	for testName, c := range fullCases {
@@ -665,10 +660,10 @@ func TestValidatePipelines(t *testing.T) {
 				}
 			}
 			//Log parsing issues as an error in test
-			if parseErrs != 0{
+			if parseErrs != 0 {
 				assert.True(t, true, false)
 			} else {
-				err := b.ValidatePipelines( d, c.dinghyRaw)
+				err := b.ValidatePipelines(d, c.dinghyRaw)
 				assert.Equal(t, c.result, err)
 			}
 		})
@@ -679,8 +674,8 @@ func TestValidateAppNotifications(t *testing.T) {
 	b := testPipelineBuilder()
 
 	fullCases := map[string]struct {
-		dinghyRaw    []byte
-		result       error
+		dinghyRaw []byte
+		result    error
 	}{
 		"dinghyraw_pass_empty": {
 			dinghyRaw: []byte(`{
@@ -758,7 +753,7 @@ func TestValidateAppNotifications(t *testing.T) {
 			}`),
 			result: errors.New("application notifications format is invalid for email"),
 		},
-		"dinghyraw_passes_arrays" : {
+		"dinghyraw_passes_arrays": {
 			dinghyRaw: []byte(`{
 				"application": "foo",
 				"spec": {
@@ -809,16 +804,15 @@ func TestValidateAppNotifications(t *testing.T) {
 				}
 			}
 			//Log parsing issues as an error in test
-			if parseErrs != 0{
+			if parseErrs != 0 {
 				assert.True(t, true, false)
 			} else {
-				err := b.ValidateAppNotifications( d, c.dinghyRaw)
+				err := b.ValidateAppNotifications(d, c.dinghyRaw)
 				assert.Equal(t, c.result, err)
 			}
 		})
 	}
 }
-
 
 func TestUpdateDinghyfileMalformed(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -1047,7 +1041,6 @@ func TestUpdatePipelinesRespectsAutoLockOff(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-
 func TestRebuildModuleRoots(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1119,7 +1112,6 @@ func TestRebuildModuleRootsProcessTemplate(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-
 func TestRebuildModuleRootsFailureCase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1167,10 +1159,10 @@ type mockNotifier struct {
 	LastError    error
 }
 
-func (m *mockNotifier) SendSuccess(org, repo, path string, notificationsType plank.NotificationsType) {
+func (m *mockNotifier) SendSuccess(org, repo, path string, notificationsType plank.NotificationsType, content map[string]interface{}) {
 	m.SuccessCalls = m.SuccessCalls + 1
 }
-func (m *mockNotifier) SendFailure(org, repo, path string, err error, notificationsType plank.NotificationsType) {
+func (m *mockNotifier) SendFailure(org, repo, path string, err error, notificationsType plank.NotificationsType, content map[string]interface{}) {
 	m.FailureCalls = m.FailureCalls + 1
 	m.LastError = err
 }
@@ -1196,16 +1188,16 @@ func TestFailureNotifier(t *testing.T) {
 
 func Test_extractApplicationName(t *testing.T) {
 	tests := []struct {
-		name    string
-		dinghyfile    string
-		want    string
-		wantErr bool
+		name       string
+		dinghyfile string
+		want       string
+		wantErr    bool
 	}{
 		{
-			name: "json_test",
+			name:       "json_test",
 			dinghyfile: `{"application": "test_app_name"}`,
-			want: "test_app_name",
-			wantErr: false,
+			want:       "test_app_name",
+			wantErr:    false,
 		},
 		{
 			name: "yaml_test",
@@ -1228,7 +1220,7 @@ pipelines:
     waitTime: 4
   {{ module "some.stage.module" "something" }}
   triggers: []`,
-			want: "my-awesome-application",
+			want:    "my-awesome-application",
 			wantErr: false,
 		},
 		{
@@ -1237,7 +1229,7 @@ pipelines:
 "globals" = {
     "waitTime" = 42
 }`,
-			want: "some-app",
+			want:    "some-app",
 			wantErr: false,
 		},
 	}

--- a/pkg/dinghyfile/builder_test.go
+++ b/pkg/dinghyfile/builder_test.go
@@ -1287,7 +1287,7 @@ func TestPipelineBuilder_getContent(t *testing.T) {
 				},
 			},
 			want: map[string]interface{}{
-				"raw": map[string]interface{}{
+				"rawdata": map[string]interface{}{
 					"head_commit": map[string]interface{}{
 						"id": "a5fc63bd5a8bdb342d1e83933a5b5c99010e61e4",
 					},
@@ -1295,7 +1295,7 @@ func TestPipelineBuilder_getContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Content should return a map populated with 'raw' and 'logevent' properties",
+			name: "Content should return a map populated with 'raw' and 'logevent' properties, since both are populated.",
 			fields: fields{
 				Logger: func() log.DinghyLog {
 					return NewDinghylogWithContent("test")
@@ -1303,9 +1303,28 @@ func TestPipelineBuilder_getContent(t *testing.T) {
 				PushRaw: map[string]interface{}{},
 			},
 			want: map[string]interface{}{
-				"raw":      map[string]interface{}{},
+				"rawdata":  map[string]interface{}{},
 				"logevent": "test",
 			},
+		},
+		{
+			name: "Content should return a map populated with 'logevent' properties, since no raw data is.",
+			fields: fields{
+				Logger: func() log.DinghyLog {
+					return NewDinghylogWithContent("test")
+				}(),
+				PushRaw: nil,
+			},
+			want: map[string]interface{}{
+				"logevent": "test",
+			},
+		},
+		{
+			name: "Content should return a empty map, since no properties are populated.",
+			fields: fields{
+				Logger: NewDinghylog(),
+			},
+			want: map[string]interface{}{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/dinghyfile/test_common.go
+++ b/pkg/dinghyfile/test_common.go
@@ -73,3 +73,18 @@ func NewDinghylog() log.DinghyLog {
 		},
 	}}
 }
+
+func NewDinghylogWithContent(content string) log.DinghyLog {
+	memLog := &bytes.Buffer{}
+	memLog.Write([]byte(content))
+	return log.DinghyLogs{Logs: map[string]log.DinghyLogStruct{
+		log.SystemLogKey: {
+			Logger:         logrus.New(),
+			LogEventBuffer: &bytes.Buffer{},
+		},
+		log.LogEventKey: {
+			Logger:         logrus.New(),
+			LogEventBuffer: memLog,
+		},
+	}}
+}

--- a/pkg/dinghyfile/test_common.go
+++ b/pkg/dinghyfile/test_common.go
@@ -65,9 +65,9 @@ func mockLogger(dr *DinghyfileParser, ctrl *gomock.Controller) *mock.MockDinghyL
 	return dr.Builder.Logger.(*mock.MockDinghyLog)
 }
 
-func NewDinghylog() log.DinghyLog{
+func NewDinghylog() log.DinghyLog {
 	return log.DinghyLogs{Logs: map[string]log.DinghyLogStruct{
-		log.SystemLogKey : {
+		log.SystemLogKey: {
 			Logger:         logrus.New(),
 			LogEventBuffer: &bytes.Buffer{},
 		},

--- a/pkg/notifiers/notifiers.go
+++ b/pkg/notifiers/notifiers.go
@@ -3,6 +3,6 @@ package notifiers
 import "github.com/armory/plank/v3"
 
 type Notifier interface {
-	SendSuccess(org, repo, path string, notifications plank.NotificationsType)
-	SendFailure(org, repo, path string, err error, notifications plank.NotificationsType)
+	SendSuccess(org, repo, path string, notifications plank.NotificationsType, content map[string]interface{})
+	SendFailure(org, repo, path string, err error, notifications plank.NotificationsType, content map[string]interface{})
 }


### PR DESCRIPTION
Update the notifiers interface so we can extend the usability and send more content to their implementations.

e.g. if some notifier needs some other information apart of the org, repo, path, notifications now we can send it via the `content` map.