### PR TITLE
fix(build): Bump action/cache and configure restore-keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,12 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Cache Build Dependencies  # Speeds up subsquent builds
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
+          restore-keys: | 
+            go-
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
## What 

I bumped the `action/cache` action to v2 to keep the action up-to-date and also improve the perf.
Also, I configured the restore keys. Currently, there are no restore keys which means the cache will not be restored.

## Ref
https://github.com/actions/cache