### PR TITLE
feat(builder): add feature flag to restrict app updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/armory-io/monitoring v0.0.7
 	github.com/armory/go-yaml-tools v0.0.2
-	github.com/armory/plank/v4 v4.0.0 // indirect
+	github.com/armory/plank/v4 v4.1.0
 	github.com/go-redis/redis v6.14.1+incompatible
 	github.com/golang/mock v1.3.1
 	github.com/google/go-github/v33 v33.0.0

--- a/go.sum
+++ b/go.sum
@@ -37,12 +37,6 @@ github.com/armory-io/monitoring v0.0.7/go.mod h1:EqWc/9ldt7teZxnS2xnAMJsthM7ldI4
 github.com/armory/go-yaml-tools v0.0.0-20180620164822-5d0947924d8e/go.mod h1:rHIvkswnJs3bWHmIDC8l+JHHpChXI/jsJBjl2JNck2w=
 github.com/armory/go-yaml-tools v0.0.2 h1:IYAbeGQJQKFwBAdl4u9IVrENgHjjUsOxZRSTvypgYk4=
 github.com/armory/go-yaml-tools v0.0.2/go.mod h1:LasFFVo6zuV334Pmx7Diq9L3muOUUI8MF79QUFC1jq0=
-github.com/armory/plank/v3 v3.4.5 h1:G3awHEQtxXrIbzQRbDaTH6NzyLJpjKICHyjWBX3MxTI=
-github.com/armory/plank/v3 v3.4.5/go.mod h1:8M359Bf4VNI2NVlgy8PG5+KpyVB8+0DaVI8KqNSpLcQ=
-github.com/armory/plank/v4 v4.0.0-20210506200752-0d08faddba2b h1:ZHlDCqDvzcQBR7nkrbvOgHze6xMo9ZiergD6sQGBRMk=
-github.com/armory/plank/v4 v4.0.0-20210506200752-0d08faddba2b/go.mod h1:xH8nrFDGCXEL+zZpLMxrdTq395DHvtrHgJmEdg9Ygo4=
-github.com/armory/plank/v4 v4.0.0-20210507183839-114b4edf7951 h1:XAhFLBG3FkKs9xIbFPYh1wnE0onZ40ck12WjfejaQFo=
-github.com/armory/plank/v4 v4.0.0-20210507183839-114b4edf7951/go.mod h1:xH8nrFDGCXEL+zZpLMxrdTq395DHvtrHgJmEdg9Ygo4=
 github.com/armory/plank/v4 v4.0.0 h1:1pGzeq4oq5fr5FL9Bo5NoRm3RLeQSLPNme7VwTMU5KU=
 github.com/armory/plank/v4 v4.0.0/go.mod h1:xH8nrFDGCXEL+zZpLMxrdTq395DHvtrHgJmEdg9Ygo4=
 github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=

--- a/pkg/dinghyfile/builder_mock.go
+++ b/pkg/dinghyfile/builder_mock.go
@@ -6,8 +6,10 @@ package dinghyfile
 
 import (
 	bytes "bytes"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	"github.com/armory/dinghy/pkg/git"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockParser is a mock of Parser interface.
@@ -205,4 +207,18 @@ func (m *MockDownloader) DecodeURL(url string) (string, string, string, string) 
 func (mr *MockDownloaderMockRecorder) DecodeURL(url interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeURL", reflect.TypeOf((*MockDownloader)(nil).DecodeURL), url)
+}
+
+// Slug implements slugger for the mock type
+func (m *MockDownloader) Slug(r map[string]interface{}) (*git.RepositoryInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Slug", r)
+	ret0, _ := ret[0].(*git.RepositoryInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockDownloaderMockRecorder) Slug(r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Slug", reflect.TypeOf((*MockDownloader)(nil).Slug), r)
 }

--- a/pkg/git/slugger.go
+++ b/pkg/git/slugger.go
@@ -1,0 +1,34 @@
+package git
+
+type RepositoryInfo struct {
+	Org  string
+	Repo string
+	Type string
+}
+
+// Slugger parses a URL from a Git provider webhook event and returns its constiuent parts.
+//
+//@&5!:..........................................      ....................:!P@@
+//G^ ~5GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBGGGGBY:    :Y55555555555555555Y?^ ~#
+//: ?&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&#BGGGB#&&&&&B7    :5GGGGGGGGGGGGGGGGGGG~ ~
+//  P&############################&BJ~:.   .:~75#&&&P^   .?GGGGGGGGGGGGGGGGGG? .
+//  5&###########################&P:            :Y&#&#J.   !PGGGGGGGGGGGGGGGG? :
+//  5&##########################&#^               5&##&G!   ^PGGGGGGGGGGGGGGG? :
+//  5&########################&#P7                ~&###&&5:  :YGGGGGGGGGGGGGG? :
+//  5&########################5!^::               ~######&#?   ?GGGGGGGGGGGGG? :
+//  5&###########################&5              :#&&&&&&&&&G~  !PGGGGGGGGGGG? :
+//  5&##########################&G:               !7777777?YBP   :!PGGGGGGGGG? :
+//  5&############################BG.                        .     .?PGGGGGGG? :
+//  5&##########################&#57.                                ~GGGGGGG? :
+//  5&####&&&&&&###############&Y:                                    ~J5GGGG? :
+//  5&###&G?~~?G&#############&J                                        .7GGG? :
+//  5&####^    ^#############&P                                           !5G? :
+//  5&###&5^::^5&############&7                                            ?G? :
+//  P&####&###&&##############:                                          .?GG? .
+//: 7&&&&&&&&&&&&&&&&&&&&&&&&#J??~                               ~777777?PGGP^ !
+//#~ ^JPPPPPPPPPPPPPPPPPPPPPPPGGGP~                              75YYYYYYYJ7: 7&
+//@@P7^...........................:.......................................:^?G@@
+type Slugger interface {
+	// NOTE: pushEvent should really be a stronger type than a generic map.
+	Slug(pushEvent map[string]interface{}) (*RepositoryInfo, error)
+}

--- a/pkg/settings/global/settings.go
+++ b/pkg/settings/global/settings.go
@@ -89,7 +89,27 @@ func NewDefaultSettings() Settings {
 			Enabled:       false,
 			EventLogsOnly: false,
 		},
+		Experimental: FeatureFlags{
+			RequireGitRepoMatch: RequireGitRepoMatch{Enabled: false},
+			DoNotUpdatePermissions: DoNotUpdatePermissions{Enabled: false},
+		},
 	}
+}
+
+// RequireGitRepoMatch requires the originating repo to match the application's repo for a pipeline.
+type RequireGitRepoMatch struct {
+	// Enabled tells us whether a customer has enabled this feature or not
+	Enabled bool `json:"enabled"`
+}
+
+// DoNotUpdatePermissions only allows the definition of Application permissions through UI
+type DoNotUpdatePermissions struct {
+  Enabled bool `json:"enabled"`
+}
+
+type FeatureFlags struct {
+	RequireGitRepoMatch `json:"requireGitRepoMatch,omitempty"`
+	DoNotUpdatePermissions `json:"doNotUpdatePermissions,omitempty"`
 }
 
 // Settings contains all information needed to startup and run the dinghy service
@@ -154,6 +174,7 @@ type Settings struct {
 	LogEventTTLMinutes time.Duration `json:"LogEventTTLMinutes" yaml:"LogEventTTLMinutes"`
 	// SQL configuration for dinghy
 	SQL Sqlconfig `json:"sql,omitempty" yaml:"sql"`
+	Experimental FeatureFlags `json:"experimental,omitempty"`
 }
 
 type Sqlconfig struct {

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -649,6 +649,7 @@ func (wa *WebAPI) buildPipelines(p Push, rawPush []byte, f dinghyfile.Downloader
 		RepositoryRawdataProcessing: settings.RepositoryRawdataProcessing,
 		Action:                      pipebuilder.Process,
 		JsonValidationDisabled:      settings.JsonValidationDisabled,
+    FeatureFlags:                settings.Experimental,
 	}
 
 	if validation {


### PR DESCRIPTION
### Summary

Dinghy runs withs service account permissions that cannot be changed at
runtime. This can create situations where permissions for a given app
restrict actions in the UI that can be changed by Dinghy.

For this reason, we're introducing a new feature flag that, when
enabled, will restrict application and pipeline updates to the
repository that created the app/pipeline combo first. This prevents the
scenario where Team A defines a pipeline for their application, and Team
B copy/pastes their pipeline definition into a separate repository. If
not careful, this could clobber Team A's work and cause
confusion/friction in the deployment process.

This feature flag is currently only implemented for GitHub providers.

### Still TODO before we can merge this PR:

- [x] Add tests
- [ ] Publish Plank changes necessary for this PR to work
- ~Implement permissions lock flag~ Not in scope for this PR
- [ ] Upgrade dependency in armory-io/dinghy
- [ ] Add documentation to github.com/armory/docs
- [ ] Coordinate w/ release team