### PR TITLE
feat(repo_config): added support for multiple branches per single repo

### DIFF
--- a/pkg/settings/global/settings.go
+++ b/pkg/settings/global/settings.go
@@ -194,12 +194,11 @@ type SpinnakerSupplied struct {
 	// Echo service information
 	Echo SpinnakerService `json:"echo,omitempty" yaml:"echo"`
 	// Gate service information
-	Gate  SpinnakerService `json:"gate,omitempty" yaml:"gate"`
+	Gate SpinnakerService `json:"gate,omitempty" yaml:"gate"`
 	// Fiat service information
 	Fiat Fiat `json:"fiat,omitempty" yaml:"fiat"`
 	// Redis service information, user will always be default
 	Redis Redis `json:"redis,omitempty" yaml:"redis"`
-
 }
 
 type Redis struct {
@@ -245,9 +244,9 @@ type RepoConfig struct {
 	Branch string `json:"branch,omitempty" yaml:"branch"`
 }
 
-func (s *Settings) GetRepoConfig(provider, repo string) *RepoConfig {
+func (s *Settings) GetRepoConfig(provider, repo, branch string) *RepoConfig {
 	for _, c := range s.RepoConfig {
-		if c.Provider == provider && c.Repo == repo {
+		if c.Provider == provider && c.Repo == repo && c.Branch == branch {
 			return &c
 		}
 	}

--- a/pkg/settings/global/settings_test.go
+++ b/pkg/settings/global/settings_test.go
@@ -27,6 +27,7 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 		settings Settings
 		provider string
 		repo     string
+		branch   string
 		expected *RepoConfig
 	}{
 		"happy path": {
@@ -38,6 +39,11 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 						Branch:   "ghbranch",
 					},
 					{
+						Provider: "github",
+						Repo:     "ghrepo",
+						Branch:   "ghanotherbranch",
+					},
+					{
 						Provider: "bitbucket",
 						Repo:     "bbrepo",
 						Branch:   "bbbranch",
@@ -46,6 +52,7 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 			},
 			provider: "bitbucket",
 			repo:     "bbrepo",
+			branch:   "bbbranch",
 			expected: &RepoConfig{
 				Provider: "bitbucket",
 				Repo:     "bbrepo",
@@ -69,17 +76,38 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 			},
 			provider: "stash",
 			repo:     "repo",
+			branch:   "branch",
 			expected: nil,
 		},
 		"no repo configuration": {
 			settings: Settings{RepoConfig: []RepoConfig{}},
 			expected: nil,
 		},
+		"branch mismatch": {
+			settings: Settings{
+				RepoConfig: []RepoConfig{
+					{
+						Provider: "github",
+						Repo:     "ghrepo",
+						Branch:   "main",
+					},
+					{
+						Provider: "github",
+						Repo:     "ghrepo",
+						Branch:   "release",
+					},
+				},
+			},
+			provider: "github",
+			repo:     "ghrepo",
+			branch:   "featurebranch",
+			expected: nil,
+		},
 	}
 
 	for testName, c := range cases {
 		t.Run(testName, func(t *testing.T) {
-			actual := c.settings.GetRepoConfig(c.provider, c.repo)
+			actual := c.settings.GetRepoConfig(c.provider, c.repo, c.branch)
 			assert.Equal(t, c.expected, actual)
 		})
 	}


### PR DESCRIPTION
The purpose of this pull request is effectively enable support for multiple branches per single repository. 

Let's use below `repoConfig` for example:
```
repoConfig:
  - provider: github
    repo: dinghy
    branch: main
  - provider: github
    repo: dinghy
    branch: test
```

Up until now fetching repository configuration - _check method GetRepoConfig_ - utilized just two attributes: `provider` and `repo`. If we had configuration like the one above, search would return the first config that matched those two attributes. As the slice of is ordered, GetRepoConfig would always return first configuration without taking `branch` into consideration. Even though two branches are configured per single repository, we would always use just one.

I aimed at changing aforementioned behavior to actually support multiple branches per the same repository. To achieve that I added `branch` into the mix of attributes that are used to find expected configuration.
