### PR TITLE
fix(config): changed two feature flags types from boolean to string.

### DIFF
--- a/pkg/settings/global/settings.go
+++ b/pkg/settings/global/settings.go
@@ -90,8 +90,8 @@ func NewDefaultSettings() Settings {
 			EventLogsOnly: false,
 		},
 		UserWritePermissionsCheckEnabled: false,
-		MultipleBranchesEnabled:          true,
-		DinghyIgnoreRegexp2Enabled:       true,
+		MultipleBranchesEnabled:          "true",
+		DinghyIgnoreRegexp2Enabled:       "true",
 	}
 }
 
@@ -158,13 +158,13 @@ type Settings struct {
 	// SQL configuration for dinghy
 	SQL Sqlconfig `json:"sql,omitempty" yaml:"sql"`
 	// Enable regexp2 for .dinghyignore file
-	DinghyIgnoreRegexp2Enabled bool `json:"dinghyIgnoreRegexp2Enabled" yaml:"dinghyIgnoreRegexp2Enabled"`
+	DinghyIgnoreRegexp2Enabled string `json:"dinghyIgnoreRegexp2Enabled" yaml:"dinghyIgnoreRegexp2Enabled"`
 	// Check user's write permissions by calling Fiat /authorize/${user}/roles before updating application
 	UserWritePermissionsCheckEnabled bool `json:"userWritePermissionsCheckEnabled" yaml:"userWritePermissionsCheckEnabled"`
 	// Users for whom we should ignore and skip write permissions validations
 	IgnoreUsersPermissions []string `json:"ignoreUsersWritePermissions" yaml:"ignoreUsersWritePermissions"`
 	// Enable processing of multiple branches in single repository
-	MultipleBranchesEnabled bool `json:"multipleBranchesEnabled" yaml:"multipleBranchesEnabled"`
+	MultipleBranchesEnabled string `json:"multipleBranchesEnabled" yaml:"multipleBranchesEnabled"`
 	// Enable using savePipeline and updatePipeline tasks from Orca
 	UpsertPipelineUsingOrcaTaskEnabled bool `json:"upsertPipelineUsingOrcaTaskEnabled" yaml:"upsertPipelineUsingOrcaTaskEnabled"`
 }
@@ -259,7 +259,7 @@ type RepoConfig struct {
 
 func (s *Settings) GetRepoConfig(provider, repo, branch string) *RepoConfig {
 	var match = func(repositoryConfiguration RepoConfig) bool {
-		if s.MultipleBranchesEnabled {
+		if "true" == s.MultipleBranchesEnabled {
 			return repositoryConfiguration.Provider == provider && repositoryConfiguration.Repo == repo && repositoryConfiguration.Branch == branch
 		}
 		return repositoryConfiguration.Provider == provider && repositoryConfiguration.Repo == repo

--- a/pkg/settings/global/settings_test.go
+++ b/pkg/settings/global/settings_test.go
@@ -85,7 +85,7 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 		},
 		"when feature flag enabled, search by provider and repo and branch": {
 			settings: Settings{
-				MultipleBranchesEnabled: true,
+				MultipleBranchesEnabled: "true",
 				RepoConfig: []RepoConfig{
 					{
 						Provider: "github",
@@ -106,7 +106,7 @@ func TestSettings_GetRepoConfig(t *testing.T) {
 		},
 		"when feature flag disabled, search just by provider and repo": {
 			settings: Settings{
-				MultipleBranchesEnabled: false,
+				MultipleBranchesEnabled: "false",
 				RepoConfig: []RepoConfig{
 					{
 						Provider: "github",

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -700,7 +700,7 @@ func (wa *WebAPI) buildPipelines(
 
 		var ignoreFile IgnoreFile
 
-		if s.DinghyIgnoreRegexp2Enabled {
+		if "true" == s.DinghyIgnoreRegexp2Enabled {
 			ignoreFile = NewRegexp2IgnoreFile(ignoreFilePatterns, l)
 		} else {
 			ignoreFile = NewRegexpIgnoreFile(ignoreFilePatterns, l)

--- a/pkg/web/routes_test.go
+++ b/pkg/web/routes_test.go
@@ -593,7 +593,7 @@ func TestShouldRunValidationWhenBranchIsWrongAndIsMaster(t *testing.T) {
 		Ref: "master",
 	}
 	s := &global.Settings{
-		MultipleBranchesEnabled: true,
+		MultipleBranchesEnabled: "true",
 		DinghyFilename:          "dinghyfile",
 		TemplateOrg:             "test_org",
 		TemplateRepo:            "test_repo",
@@ -696,7 +696,7 @@ func TestBuildPipelinesWhenDinghyIgnoreRegexp2Enabled(t *testing.T) {
 			},
 		},
 		GitHubToken:                "test_github_token",
-		DinghyIgnoreRegexp2Enabled: true,
+		DinghyIgnoreRegexp2Enabled: "true",
 	}
 
 	sc := source.NewMockSourceConfiguration(c)
@@ -753,7 +753,7 @@ func TestBuildPipelinesWhenDinghyIgnoreRegexp2Disabled(t *testing.T) {
 			},
 		},
 		GitHubToken:                "test_github_token",
-		DinghyIgnoreRegexp2Enabled: false,
+		DinghyIgnoreRegexp2Enabled: "false",
 	}
 
 	sc := source.NewMockSourceConfiguration(c)


### PR DESCRIPTION
When merging two configurations - the default one defined in the application’s code and the user-defined one - if a feature flag is set to false in the user config but set to true in the default config, the default value will take precedence over the user-defined value. In such case, it is impossible to disable the feature.